### PR TITLE
replaced words.split with text.split

### DIFF
--- a/_posts/2016/feb/2016-02-09-are-you-still-debugging.md
+++ b/_posts/2016/feb/2016-02-09-are-you-still-debugging.md
@@ -114,7 +114,7 @@ class Words implements Iterable<String> {
       "UTF-8"
     );
     Set<String> words = new HashSet<>();
-    for (String word : words.split(" ")) {
+    for (String word : text.split(" ")) {
       words.add(word);
     }
     return words.iterator();


### PR DESCRIPTION
A small bug I found while reading the article, no debugging was necessary :)