### PR TITLE
Corrected CSS class for GitHub icon

### DIFF
--- a/_layouts/static.html
+++ b/_layouts/static.html
@@ -17,7 +17,7 @@ layout: default
         This blog is built with <a href="http://jekyllrb.com/">Jekyll</a>
         and hosted on <a href="https://pages.github.com/">GitHub Pages</a>
         <br/>
-        <a href="https://github.com/yegor256/blog/commit/{{ site.data['hash'] }}"><i class="ico ico-x-github"></i></a>
+        <a href="https://github.com/yegor256/blog/commit/{{ site.data['hash'] }}"><i class="icon icon-github"></i></a>
       </p>
     </footer>
   </div>


### PR DESCRIPTION
I've just bought your book and was taking a look around your blog, (and being nosey - viewing source, etc), and noticed that the class for the GitHub icon at the bottom of your pages was incorrect.

I hope this helps?

I look forward to reading your book.