### PR TITLE
Updating the code example.

### DIFF
--- a/_posts/2016/dec/2016-12-13-mvc-vs-oop.md
+++ b/_posts/2016/dec/2016-12-13-mvc-vs-oop.md
@@ -70,7 +70,7 @@ printf(
     new FormattedSpeed( // controller
       new SpeedFromEngine() // model
     )
-  )
+  ).to_str();
 );
 {% endhighlight %}
 


### PR DESCRIPTION
I know it's only pseudo code, and this is a trivial change, but shouldn't we see the call to `.to_str()` here?