### PR TITLE
Removed "final" from singleton's INSTANCE field

### DIFF
--- a/_posts/2017/nov/2017-11-07-five-new-java-features.md
+++ b/_posts/2017/nov/2017-11-07-five-new-java-features.md
@@ -43,7 +43,7 @@ have them, why doesn't Java? Look at this code:
 
 {% highlight java %}
 class User {
-  private static final User INSTANCE;
+  private static User INSTANCE;
   private User() {}
   public static User getInstance() {
     synchronized (User.INSTANCE) {


### PR DESCRIPTION
As the value of `INSTANCE` field is assigned lazily, the static field can not be final.
In another words original code does not compile with the `error: cannot assign a value to final variable INSTANCE`.

Therefore I've removed `final` modifier.