### PR TITLE
fix past talk entry

### DIFF
--- a/static/talks.md
+++ b/static/talks.md
@@ -139,7 +139,7 @@ so why shouldn't we rate them, right? The best grade is
 
 <div class="talk-event"/>
 <aside class="venue-rate green">B+</aside>
-<img src="/images/2017/devternity.png" class="future-talk" alt="DevTernity 2017"/>
+<img src="/images/2017/devternity.png" class="past-talk" alt="DevTernity 2017"/>
 How Much Do You Cost?
 [DevTernity 2017](https://devternity.com/);
 Riga, Latvia;


### PR DESCRIPTION
Fixes number of displayed future talks (2 instead of 3):
<img width="517" alt="screen shot 2017-12-14 at 22 53 54" src="https://user-images.githubusercontent.com/11976836/34018670-d60f03ca-e122-11e7-990f-fd1a009e974b.png">
