### PR TITLE
Scalars should not instantiate decorators

### DIFF
--- a/static/agenda.md
+++ b/static/agenda.md
@@ -21,6 +21,8 @@ months. If you want to add something here, please
 
 <!--more-->
 
+How big should Scala blocks be?
+
 When should you implement more than one interface instead of using a decorator?
 
 Support principles. Free, Paid, Fast, Slow, Open Source, Commercial. What's the right approach that everyone should adopt?


### PR DESCRIPTION
Assuming everything in elegant objects is a decorator except for low-level Java objects (i.e. primitives). 

`Scalar` implies **processing**, if composition is done correctly, only low-level processing (i.e. arithmetic) should be necessary.

Instantiating decorator objects in a `Scalar` is a code smell, it means that there is a composition flaw.

When using `Scalar` from cactoos, you can end up with constructors that contain a lot of "executable" code that's lazy loaded. This is displacing the quality gains from going "pure OOP". There should be a rule on the correct approach.

**Wrong Approach 1**

```
public Foo() {
   this.bar = () -> new Bar();
}
```

**Wrong Approach 2**

```
public Foo() {
    this.bar = () -> {
        Bar bar1;
        //insert 50 lines of code here
        return bar1;
    }
}
```

I believe the only time a lazy loaded value should be used is with low-level Java objects (probably [these](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html) but most likely also collections and other things).

**Correct Approach**

```
public Foo(final Integer integer1, final Integer integer2) {
   this.total = () -> integer1 + integer2;
}
```

I would not be against you giving me credit for the find :+1: 