### PR TITLE
Proposition for another test anti-pattern: Aunt Becky

### DIFF
--- a/_posts/2018/dec/2018-12-11-unit-testing-anti-patterns.md
+++ b/_posts/2018/dec/2018-12-11-unit-testing-anti-patterns.md
@@ -146,6 +146,12 @@ Afraid of getting too close to the class they are trying to test, these tests
 act at a distance, separated by countless layers of abstraction
 and thousands of lines of code from the logic they are checking.
 
+**Aunt Becky* (aka "I'm always right!").
+A test doesn't validate any behaviour and passes in every scenario. Any new bug introduced
+in the code will never be discovered by this test. It was probably created after the 
+implementation was finished, so the author of this test couldn't know whether the test
+actually tests something.
+
 Useful links:
 
   1. [_Spock: Up and Running_](https://amzn.to/2BaAKRB) by Rob Fletcher


### PR DESCRIPTION
Example:

 - User writes implementation:
    ```java
    String getErrorMessage() {
     if (success) return "Message is valid";
     return "Message is invalid";
    }
    ```
 - User writes test that passes:
    ```java
    assertThat(getErrorMessage()).contains("valid");
    ```
  - Test passes
  - User is happy that he has a good test
  - In reality - test is incapable of finding a bug 