### PR TITLE
fix: remove unneeded U+2028

### DIFF
--- a/_latex/resume-boring.tex
+++ b/_latex/resume-boring.tex
@@ -33,8 +33,8 @@
 
 \section*{Yegor Bugayenko}
 
-\href{mailto:yegor256@gmail.com}{yegor256@gmail.com}\\ %
-\href{https://www.yegor256.com}{www.yegor256.com}\\% 
+\href{mailto:yegor256@gmail.com}{yegor256@gmail.com}\\%
+\href{https://www.yegor256.com}{www.yegor256.com}\\%
 (408) 692-4742\\%
 \href{https://github.com/yegor256}{GitHub} /
 \href{https://stackexchange.com/users/63162/yegor256}{StackOverflow} /

--- a/_latex/resume.tex
+++ b/_latex/resume.tex
@@ -32,7 +32,7 @@
 }\end{textblock}
 
 \textbf{\Large Yeg\'or Bugay\'enko}\\%
-\href{mailto:yegor256@gmail.com}{yegor256@gmail.com}\\ %
+\href{mailto:yegor256@gmail.com}{yegor256@gmail.com}\\%
 (408) 692-4742
 
 \vspace{1em}


### PR DESCRIPTION
Hi,

I'm updating [`latexonline.cc`](https://latexonline.cc) service to the new TexLive2020 distribution, and I noticed that your document doesn't compile there.

Here's a quick fix that removes unexpected U+2028 from your source. 