### PR TITLE
Fix `modified` filter to actually return HTML

### DIFF
--- a/_plugins/modified.rb
+++ b/_plugins/modified.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'date'
+require 'shellwords'
 
 # My module
 module Yegor
@@ -11,15 +12,13 @@ module Yegor
   module Modified
     def modified(page)
       path = page['path']
-      count = `git rev-list HEAD --count #{path}`.strip.to_i
-      if count > 1
-        date = Time.parse(`git log -n 1 --date=iso --format=%ad #{path}`.strip)
-        if date > page['date']
-          "<li class='unprintable desktop-only'><a href='https://github.com/yegor256/blog/commits/master/#{path}'>Modified</a>\
-          on <time itemprop='dateModified' datetime='#{date.strftime('%Y-%m-%dT%H:%M:%S%z')}'>#{date.strftime('%-d %B %Y')}</time></li>"
-        end
-      end
-      print '.'
+      escaped = Shellwords.escape(path)
+      count = `git rev-list HEAD --count #{escaped}`.strip.to_i
+      return '' if count <= 1
+      date = Time.parse(`git log -n 1 --date=iso --format=%ad #{escaped}`.strip)
+      return '' if date <= page['date']
+      "<li class='unprintable desktop-only'><a href='https://github.com/yegor256/blog/commits/master/#{path}'>Modified</a>\
+      on <time itemprop='dateModified' datetime='#{date.strftime('%Y-%m-%dT%H:%M:%S%z')}'>#{date.strftime('%-d %B %Y')}</time></li>"
     end
   end
 end


### PR DESCRIPTION
## Summary

`_plugins/modified.rb` defined a Liquid filter whose last expression was `print '.'`, which returns `nil`. Because Ruby methods return their last expression, the HTML built inside the `if count > 1` / `if date > page['date']` branches was thrown away and the filter always emitted an empty string.

## Fix

- Restructure the method with early returns so the HTML is the final expression.
- Drop the stray `print '.'` progress dot.
- Escape `path` before interpolating it into the two `git` shell commands.

## Test plan

- [ ] `bundle exec jekyll build` — posts that have been edited after publication should now render a "Modified on …" line in the footer again.
- [ ] `bundle exec rubocop _plugins/modified.rb` passes.

https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn

---
_Generated by [Claude Code](https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn)_