### PR TITLE
Serve codecogs equation images over HTTPS

### DIFF
--- a/_plugins/equation.rb
+++ b/_plugins/equation.rb
@@ -13,8 +13,8 @@ module Yegor
     end
 
     def render(_context)
-      "<img src='http://latex.codecogs.com/svg.image?#{CGI.escape(@tex).gsub('+',
-                                                                             '%20')}' class='eqtn' alt='equation'/>"
+      "<img src='https://latex.codecogs.com/svg.image?#{CGI.escape(@tex).gsub('+',
+                                                                              '%20')}' class='eqtn' alt='equation'/>"
     end
   end
 end


### PR DESCRIPTION
## Summary

`{% eqtn ... %}` rendered an `<img>` with an `http://latex.codecogs.com/...` URL. On an HTTPS site, browsers treat that as mixed content and refuse to load the image, so equations didn't show up.

Switched the URL to `https://`.

## Test plan

- [ ] Build a post that uses `{% eqtn ... %}` and confirm the SVG renders without a mixed-content warning in the browser console.

https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn

---
_Generated by [Claude Code](https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn)_