### PR TITLE
Guard `Yegor::Img` against non-slash src values

### DIFF
--- a/_plugins/pictures.rb
+++ b/_plugins/pictures.rb
@@ -8,15 +8,12 @@ module Yegor
   # The class
   class Img
     def initialize(src, _ctx)
-      if src.index('/').zero? && src.index('//') != 0
-        @url = src
-        raise "File doesn't exist: #{src}" unless
-          File.exist?("./_site#{src}") ||
-          File.exist?(".#{src}") ||
-          src.include?('gnuplot')
-      else
-        @url = src
-      end
+      @url = src
+      return unless src.start_with?('/') && !src.start_with?('//')
+      raise "File doesn't exist: #{src}" unless
+        File.exist?("./_site#{src}") ||
+        File.exist?(".#{src}") ||
+        src.include?('gnuplot')
     end
 
     def to_s


### PR DESCRIPTION
## Summary

`Yegor::Img#initialize` did:

```ruby
if src.index('/').zero? && src.index('//') != 0
```

If `src` contains no `/` (e.g. a bare filename), `src.index('/')` is `nil` and `.zero?` raises `NoMethodError`. Replace with `src.start_with?('/') && !src.start_with?('//')` — same intent (absolute local path, not protocol-relative URL) without the crash. Also collapsed the if/else since both branches set `@url = src`.

## Test plan

- [ ] `bundle exec jekyll build` — no change for existing posts (all call sites pass absolute paths starting with `/`).
- [ ] Sanity: a `{% figure foo.png 200 %}` with no leading slash no longer crashes.

https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn

---
_Generated by [Claude Code](https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn)_