### PR TITLE
Fix `yb_keywords` too-few check to cover `length == 1`

### DIFF
--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -11,7 +11,7 @@ module Yegor
       list = page['keywords']
       list = [] if list.nil?
       raise "too many keywords in [#{page['url']}]: #{list}" if list.length > 8
-      raise "too few keywords in [#{page['title']}]: #{list.length}" if list.length > 1 && list.length < 3
+      raise "too few keywords in [#{page['title']}]: #{list.length}" if list.length.positive? && list.length < 3
       # list.each { |word|
       #   if page['content'].index(word).nil? && page['description'].index(word).nil?
       #     fail "keyword '#{word}' is not found in #{page['title']}"


### PR DESCRIPTION
## Summary

`yb_keywords` in `_plugins/filters.rb` validated "at least 3 keywords, if any are given":

```ruby
raise "too few keywords..." if list.length > 1 && list.length < 3
```

But `> 1 && < 3` only matches `length == 2`. A page with exactly one keyword sailed through the check. Replaced with `list.length.positive? && list.length < 3` so both 1-keyword and 2-keyword pages fail loudly.

An empty list (0 keywords) is still allowed — that is consistent with the "`list = []` if nil" branch above.

## Test plan

- [ ] `bundle exec jekyll build` on the full site still succeeds (existing posts all have ≥3 or 0 keywords).
- [ ] Add a temporary post with `keywords: [one]` and confirm the build now fails with "too few keywords".

https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn

---
_Generated by [Claude Code](https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn)_