### PR TITLE
Check gnuplot child process with `success?`, not `exitstatus`

### DIFF
--- a/_plugins/gnuplot.rb
+++ b/_plugins/gnuplot.rb
@@ -35,7 +35,7 @@ module Jekyll
           mkdir -p ${dir}/_temp/gnuplot/#{path}
           mv #{base}.svg ${dir}/_temp/gnuplot/#{path}
         `
-        raise 'failed to build gnuplot image' unless $CHILD_STATUS.exitstatus
+        raise 'failed to build gnuplot image' unless $CHILD_STATUS.success?
         site.static_files << Jekyll::GnuplotFile.new(site, site.dest, 'gnuplot', "#{path}/#{base}.svg")
       end
     end

--- a/_plugins/stats.rb
+++ b/_plugins/stats.rb
@@ -118,7 +118,7 @@ module Jekyll
         cp ${tmp}/stats.svg ${src}/_site/stats.svg
         "
       )
-      raise 'failed to build gnuplot stats image' unless $CHILD_STATUS.exitstatus
+      raise 'failed to build gnuplot stats image' unless $CHILD_STATUS.success?
       site.static_files << Jekyll::StatsFile.new(site, site.dest, '', 'stats.svg')
       site.static_files << Jekyll::StatsFile.new(site, site.dest, '', 'words.txt')
       puts 'stats.svg generated'


### PR DESCRIPTION
## Summary

Both `_plugins/gnuplot.rb` and `_plugins/stats.rb` guarded their gnuplot shell invocations with:

```ruby
raise '...' unless $CHILD_STATUS.exitstatus
```

`$CHILD_STATUS.exitstatus` returns an Integer (0 on success, non-zero on failure). In Ruby, every integer is truthy, so `unless <integer>` is always false — the raise never fires. A failing `gnuplot` invocation silently produced no SVG and the build kept going with a missing image.

Switched to `unless $CHILD_STATUS.success?`, which is true only when the process exited with status 0.

## Test plan

- [ ] `bundle exec jekyll build` still succeeds for the happy path.
- [ ] Sanity: temporarily break a `.gpi` file and confirm the build now fails loudly instead of silently omitting the SVG.

https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn

---
_Generated by [Claude Code](https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn)_