### PR TITLE
Report actual typo count, not `Integer#size`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -210,7 +210,7 @@ task spell: [:build] do
     end
     unless typos.zero?
       puts "All typos:\n  #{bad_words.uniq.join("\n  ")}"
-      raise "#{typos.size} typo(s) in #{bad_pages} pages"
+      raise "#{typos} typo(s) in #{bad_pages} pages"
     end
     throw :'No spelling errors'
   end


### PR DESCRIPTION
## Summary

The `spell` Rake task reduces into `typos` as an Integer (the total count of misspelled words). The error message then called `typos.size`, which for an Integer returns the native machine word size (8 on a 64-bit host), so every failed spellcheck read "8 typo(s) in N pages" regardless of the real count.

Interpolate `typos` directly.

## Test plan

- [ ] `rake spell` on a deliberately-broken post now reports the actual number of typos.

https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn

---
_Generated by [Claude Code](https://claude.ai/code/session_011JpVRXca2YM3Bwsf8uH2Wn)_