### PR TITLE
[codex] Fix code block overflow near YouTube aside

### DIFF
--- a/_sass/_highlight.scss
+++ b/_sass/_highlight.scss
@@ -37,12 +37,12 @@ pre {
 .highlighter-rouge pre {
   border-left: 3 * $px solid $silver;
   margin-left: 2 * $rem;
+  overflow-x: auto;
   padding-left: .5 * $rem !important;
 
   @media all and (max-width: $width) {
     border-left: 0;
     margin-left: 0;
-    overflow-x: auto;
     padding-left: 0 !important;
   }
 


### PR DESCRIPTION
﻿Fixes #926.

What changed:
- `_sass/_highlight.scss` now applies `overflow-x: auto` to highlighted `pre` blocks outside the mobile media query too.
- The existing mobile border and margin reset is unchanged.

Why:
- Fenced text blocks can contain long monospaced lines next to floated `.youtube` asides.
- On desktop, those blocks did not get the horizontal overflow behavior that mobile already had, so long lines could spill into the aside area.
- Making the highlighted `pre` a horizontal scroll container keeps long lines inside the code block.

Validation:
- `scss-lint _sass/_highlight.scss`
- `sass-embedded` compiled `css/layout.scss`; output was 11592 bytes and included `.highlighter-rouge pre` with `overflow-x:auto`
- Headless Chrome reproduction reported `overflowX:auto`, `scrollable:true`, `clientWidth:471`, `scrollWidth:2018`
- `git diff --check`
- `gitleaks stdin` on the diff: no leaks found
- `gitleaks dir _sass/_highlight.scss`: no leaks found

Limitations:
- Full `bundle exec jekyll build` was not completed locally. This machine has Ruby 3.2.11, while the current lockfile pins `async 2.39.0`, `io-event 1.15.1`, and `parallel 2.1.0`, each requiring Ruby >= 3.3. Docker is not installed here.
